### PR TITLE
inline `stringify`

### DIFF
--- a/html.js
+++ b/html.js
@@ -10,15 +10,6 @@ const escapeRegExp = new RegExp(`[${Object.keys(escapeDict).join("")}]`, "gv");
 
 const escapeReplacer = (key) => escapeDict[key];
 
-const stringify = (exp) =>
-  typeof exp === "string"
-    ? exp
-    : exp == undefined
-    ? ""
-    : Array.isArray(exp)
-    ? exp.join("")
-    : `${exp}`;
-
 /**
  * @param {{ raw: string[] }} literals
  * @param {...*} expressions
@@ -37,7 +28,14 @@ const html = ({ raw: literals }, ...expressions) => {
 
   for (let i = 0; i < lastLitIndex; ++i) {
     let lit = literals[i];
-    let str = stringify(expressions[i]);
+    let str =
+      typeof expressions[i] === "string"
+        ? expressions[i]
+        : expressions[i] == undefined
+        ? ""
+        : Array.isArray(expressions[i])
+        ? expressions[i].join("")
+        : `${expressions[i]}`;
 
     if (lit.length > 0 && lit.charAt(lit.length - 1) === "!") {
       lit = lit.slice(0, -1);

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
   "name": "@gurgunday/html",
   "description": "Replace your template engine with fast JavaScript by leveraging the power of tagged templates.",
-  "version": "6.5.1",
+  "author": "Gürgün Dayıoğlu",
+  "license": "MIT",
+  "version": "6.5.2",
   "type": "module",
   "main": "./html.js",
   "exports": {
     ".": "./html.js",
     "./*.js": "./*.js"
   },
-  "files": [
-    "*.js"
-  ],
   "engines": {
     "node": ">=20"
   },
@@ -18,8 +17,9 @@
     "type": "git",
     "url": "https://github.com/gurgunday/html.git"
   },
-  "author": "Gürgün Dayıoğlu",
-  "license": "MIT",
+  "files": [
+    "*.js"
+  ],
   "keywords": [
     "escape-html",
     "tagged-template-literal",


### PR DESCRIPTION
The `html` tag may deal with very long string expressions, and in JavaScript, primitives are passed by value, which means they theoretically get duplicated when passed to the `stringify` function – this degrades performance for obvious reasons even after V8's optimizations