### PR TITLE
remove check for `length === 1`

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -11,7 +11,7 @@ const escapeRegExp = new RegExp(
   "gv",
 );
 
-const escapeReplacerFunction = (key) => escapeDictionary[key];
+const escapeFunction = (key) => escapeDictionary[key];
 
 /**
  * @param {{ raw: string[] }} literals
@@ -37,7 +37,7 @@ const html = (literals, ...expressions) => {
     if (lit.length !== 0 && lit.charAt(lit.length - 1) === "!")
       lit = lit.slice(0, -1);
     else if (exp.length !== 0)
-      exp = exp.replace(escapeRegExp, escapeReplacerFunction);
+      exp = exp.replace(escapeRegExp, escapeFunction);
 
     acc += lit += exp;
   }

--- a/src/html.js
+++ b/src/html.js
@@ -26,10 +26,10 @@ const html = ({ raw: literals }, ...expressions) => {
       return literals[0];
   }
 
-  const lastLitIndex = literals.length - 1;
+  const lastLitI = literals.length - 1;
   let acc = "";
 
-  for (let i = 0; i < lastLitIndex; ++i) {
+  for (let i = 0; i < lastLitI; ++i) {
     let lit = literals[i];
     let exp =
       typeof expressions[i] === "string"
@@ -48,7 +48,7 @@ const html = ({ raw: literals }, ...expressions) => {
     acc += lit += exp;
   }
 
-  acc += literals[lastLitIndex];
+  acc += literals[lastLitI];
 
   return acc;
 };

--- a/src/html.js
+++ b/src/html.js
@@ -18,19 +18,19 @@ const escapeReplacerFunction = (key) => escapeDictionary[key];
  * @param {...*} expressions
  * @returns {string}
  */
-const html = ({ raw: literals }, ...expressions) => {
-  switch (literals.length) {
+const html = (literals, ...expressions) => {
+  switch (literals.raw.length) {
     case 0:
       return "";
     case 1:
-      return literals[0];
+      return literals.raw[0];
   }
 
-  const lastLitI = literals.length - 1;
+  const lastLitI = literals.raw.length - 1;
   let acc = "";
 
   for (let i = 0; i < lastLitI; ++i) {
-    let lit = literals[i];
+    let lit = literals.raw[i];
     let exp =
       typeof expressions[i] === "string"
         ? expressions[i]
@@ -48,7 +48,7 @@ const html = ({ raw: literals }, ...expressions) => {
     acc += lit += exp;
   }
 
-  acc += literals[lastLitI];
+  acc += literals.raw[lastLitI];
 
   return acc;
 };

--- a/src/html.js
+++ b/src/html.js
@@ -18,13 +18,13 @@ const escapeFunction = (key) => escapeDictionary[key];
  * @param {...*} expressions
  * @returns {string}
  */
-const html = (literals, ...expressions) => {
-  if (literals.raw.length === 0) return "";
-  const lastLitI = literals.raw.length - 1;
+const html = ({ raw: literals }, ...expressions) => {
+  if (literals.length === 0) return "";
+  const lastLitI = literals.length - 1;
   let acc = "";
 
   for (let i = 0; i < lastLitI; ++i) {
-    let lit = literals.raw[i];
+    let lit = literals[i];
     let exp =
       typeof expressions[i] === "string"
         ? expressions[i]
@@ -42,7 +42,7 @@ const html = (literals, ...expressions) => {
     acc += lit += exp;
   }
 
-  acc += literals.raw[lastLitI];
+  acc += literals[lastLitI];
 
   return acc;
 };

--- a/src/html.js
+++ b/src/html.js
@@ -30,7 +30,7 @@ const html = ({ raw: literals }, ...expressions) => {
         ? expressions[i]
         : null == expressions[i]
           ? ""
-          : Array.isArray(expressions[i])
+          : Array.isArray(expressions[i]) === true
             ? expressions[i].join("")
             : `${expressions[i]}`;
 

--- a/src/html.js
+++ b/src/html.js
@@ -19,13 +19,7 @@ const escapeReplacerFunction = (key) => escapeDictionary[key];
  * @returns {string}
  */
 const html = (literals, ...expressions) => {
-  switch (literals.raw.length) {
-    case 0:
-      return "";
-    case 1:
-      return literals.raw[0];
-  }
-
+  if (literals.raw.length === 0) return ""
   const lastLitI = literals.raw.length - 1;
   let acc = "";
 

--- a/src/html.js
+++ b/src/html.js
@@ -19,7 +19,7 @@ const escapeReplacerFunction = (key) => escapeDictionary[key];
  * @returns {string}
  */
 const html = (literals, ...expressions) => {
-  if (literals.raw.length === 0) return ""
+  if (literals.raw.length === 0) return "";
   const lastLitI = literals.raw.length - 1;
   let acc = "";
 


### PR DESCRIPTION
The switch doesn't make much sense: if the literal array is of length 1, the function will still work fast since the for loop's condition won't be met, and we'll just return the fist/last literal – all of this just to remove one check for most use cases, not much but not nothing